### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prefixed-api-key",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "license": "MIT",
   "description": "Generate seam-style API-keys",
@@ -10,7 +10,6 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.182",
     "@types/node": "^17.0.32",
     "ava": "^4.2.0",
     "esbuild": "^0.14.38",
@@ -19,7 +18,6 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "bs58": "^5.0.0",
-    "lodash": "^4.17.21"
+    "bs58": "^5.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { randomBytes, createHash } from "node:crypto"
 import { promisify } from "node:util"
 import bs58 from "bs58"
-import padStart from "lodash/padStart"
 
 export const hashLongToken = (longToken: string) =>
   createHash("sha256").update(longToken).digest("hex")
@@ -28,14 +27,12 @@ export const generateAPIKey = async ({
     generatedRandomBytes(longTokenLength),
   ])
 
-  let shortToken = padStart(
-    bs58.encode(shortTokenBytes),
+  let shortToken = bs58.encode(shortTokenBytes).padStart(
     shortTokenLength,
     "0"
   ).slice(0, shortTokenLength)
 
-  const longToken = padStart(
-    bs58.encode(longTokenBytes),
+  const longToken = bs58.encode(longTokenBytes).padStart(
     longTokenLength,
     "0"
   ).slice(0, longTokenLength)

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -18,3 +18,16 @@ test("generate api key should return an empty object when there is no keyPrefix"
   t.falsy(apiKey.shortToken)
   t.falsy(apiKey.token)
 })
+
+test("generate api key should return strings with the correct length", async (t) => {
+  const shortTokenLength = 10;
+  const longTokenLength = 20;
+  const apiKey = await generateAPIKey({
+    keyPrefix: "mycompany",
+    shortTokenLength: shortTokenLength,
+    longTokenLength: longTokenLength,
+  })
+
+  t.truthy(apiKey.longToken && apiKey.longToken.length === longTokenLength)
+  t.truthy(apiKey.shortToken && apiKey.shortToken.length === shortTokenLength)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,11 +23,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@types/lodash@^4.14.182":
-  version "4.14.182"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
-  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
-
 "@types/node@^17.0.32":
   version "17.0.32"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.32.tgz#51d59d7a90ef2d0ae961791e0900cad2393a0149"
@@ -894,7 +889,7 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Pretty much what the title says :)
Removed the lodash dependency (`padStart` is available in plain JS by now), increased the version to `1.1.1` and wrote an additional test to confirm that the returned tokens have the expected length. 