### PR TITLE
Use timing safe string comparison in checkAPIKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,6 @@ export const checkAPIKey = (
   expectedLongTokenHash: string
 ): boolean => {
   const expectedLongTokenHashBuffer = Buffer.from(expectedLongTokenHash, 'hex');
-  const inputLongTokenHash = hashLongTokenToBuffer(extractLongToken(token))
-  return timingSafeEqual(expectedLongTokenHashBuffer, inputLongTokenHash)
+  const inputLongTokenHashBuffer = hashLongTokenToBuffer(extractLongToken(token))
+  return timingSafeEqual(expectedLongTokenHashBuffer, inputLongTokenHashBuffer)
 }


### PR DESCRIPTION
More about timing attacks here: https://security.stackexchange.com/questions/83660/simple-string-comparisons-not-secure-against-timing-attacks

Closes https://github.com/seamapi/prefixed-api-key/issues/1 (it seems the other subtasks were completed)